### PR TITLE
Mobile card now available and additional capabilities added

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,23 +3,59 @@
     "name": {
         "en": "Squeezebox"
     },
+    "category": "music",
     "description": {
         "en": "Allows control of Squeezeboxes connected to a Logitech Media Server."
     },
+    "version": "0.2.0",
+    "compatibility": ">=0.10.0",
+    "permissions": [],
     "author": {
         "name": "Mark Tudor",
         "email": "code@icefusion.co.uk"
     },
-    "category": "music",
+    "contributors": {
+        "developers": [
+            {
+                "name": "Robin van Kekem",
+                "email": "roady1979@gmail.com"
+            }
+        ]
+    },
     "images": {
         "large": "./assets/images/large.jpg",
         "small": "./assets/images/small.jpg"
     },
-    "version": "0.1.0",
-    "compatibility": ">=0.10.0",
-    "permissions": [],
     "dependencies": {
         "squeezenode": "*"
+    },
+    "capabilities": {
+        "mediacontrol": {
+            "type": "enum",
+            "title": {
+                "en": "Media Control"
+            },
+            "values": [
+                {
+                    "id": "previous",
+                    "title": {
+                        "en": "Previous"
+                    }
+                }, {
+                    "id": "pause",
+                    "title": {
+                        "en": "Pause"
+                    }
+                }, {
+                    "id": "next",
+                    "title": {
+                        "en": "Next"
+                    }
+                }
+            ],
+            "getable": false,
+            "setable": true
+        }
     },
     "drivers": [
         {
@@ -34,6 +70,7 @@
             "class": "other",
             "capabilities": [
                 "onoff",
+                "mediacontrol",
                 "volume_set"
             ],
             "pair": [
@@ -48,7 +85,33 @@
                     "id": "add_my_devices",
                     "template": "add_devices"
                 }
-            ]
+            ],
+            "mobile": {
+                "components": [
+                    {
+                        "id": "icon",
+                        "capabilities": ["onoff"]
+                    }, {
+                        "id": "ternary",
+                        "capabilities": ["mediacontrol"],
+                        "options": {
+                            "icons"	: {
+                                "top": "/drivers/squeezebox/assets/images/icons/backward.svg",
+                                "middle": "/drivers/squeezebox/assets/images/icons/pause.svg",
+                                "bottom": "/drivers/squeezebox/assets/images/icons/forward.svg"
+                            },
+                            "values": {
+                                "top": "previous",
+                                "middle": "pause",
+                                "bottom": "next"
+                            }
+                        }
+                    }, {
+                        "id":"slider",
+                        "capabilities":["volume_set"]
+                    }
+                ]
+            }
         }
     ],
     "flow": {

--- a/drivers/squeezebox/assets/images/icons/backward.svg
+++ b/drivers/squeezebox/assets/images/icons/backward.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1642"
+   height="1638.88"
+   viewBox="0 0 1642 1638.88"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="backward.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1842"
+     inkscape:window-height="1057"
+     id="namedview6"
+     showgrid="false"
+     fit-margin-left="50"
+     fit-margin-top="50"
+     fit-margin-right="50"
+     fit-margin-bottom="50"
+     inkscape:zoom="0.37249375"
+     inkscape:cx="1251.6412"
+     inkscape:cy="896.30464"
+     inkscape:window-x="70"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="m 1547,64.44 q 19,-19 32,-13 13,6 13,32 l 0,1472 q 0,26 -13,32 -13,6 -32,-13 l -710,-710 q -8,-9 -13,-19 l 0,710 q 0,26 -13,32 -13,6 -32,-13 l -710,-710 q -19,-19 -19,-45 0,-26 19,-45 l 710,-710 q 19,-19 32,-13 13,6 13,32 l 0,710 q 5,-11 13,-19 z"
+     id="path4"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/drivers/squeezebox/assets/images/icons/forward.svg
+++ b/drivers/squeezebox/assets/images/icons/forward.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1642"
+   height="1638.88"
+   viewBox="0 0 1642 1638.88"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="forward.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1842"
+     inkscape:window-height="1057"
+     id="namedview6"
+     showgrid="false"
+     fit-margin-top="50"
+     fit-margin-left="50"
+     fit-margin-bottom="50"
+     fit-margin-right="50"
+     inkscape:zoom="0.13169643"
+     inkscape:cx="882"
+     inkscape:cy="819.44"
+     inkscape:window-x="70"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="m 95,1574.44 q -19,19 -32,13 -13,-6 -13,-32 l 0,-1472 q 0,-26 13,-32 13,-6 32,13 l 710,710 q 8,8 13,19 l 0,-710 q 0,-26 13,-32 13,-6 32,13 l 710,710 q 19,19 19,45 0,26 -19,45 l -710,710 q -19,19 -32,13 -13,-6 -13,-32 l 0,-710 q -5,10 -13,19 z"
+     id="path4"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/drivers/squeezebox/assets/images/icons/pause.svg
+++ b/drivers/squeezebox/assets/images/icons/pause.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1636"
+   height="1636"
+   viewBox="0 0 1636 1636"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="pause.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1842"
+     inkscape:window-height="1057"
+     id="namedview6"
+     showgrid="false"
+     fit-margin-top="50"
+     fit-margin-left="50"
+     fit-margin-bottom="50"
+     fit-margin-right="50"
+     inkscape:zoom="0.13169643"
+     inkscape:cx="818"
+     inkscape:cy="818"
+     inkscape:window-x="70"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="m 1586,114 0,1408 q 0,26 -19,45 -19,19 -45,19 l -512,0 q -26,0 -45,-19 -19,-19 -19,-45 l 0,-1408 q 0,-26 19,-45 19,-19 45,-19 l 512,0 q 26,0 45,19 19,19 19,45 z m -896,0 0,1408 q 0,26 -19,45 -19,19 -45,19 l -512,0 q -26,0 -45,-19 -19,-19 -19,-45 L 50,114 Q 50,88 69,69 88,50 114,50 l 512,0 q 26,0 45,19 19,19 19,45 z"
+     id="path4"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/drivers/squeezebox/driver.js
+++ b/drivers/squeezebox/driver.js
@@ -51,15 +51,124 @@ module.exports.pair = function (socket) {
 };
 
 module.exports.capabilities = {
-    play: {
-        // Retrieve whether the specified Squeezebox is currently playing.
+    onoff: {
         get: function (device_data, callback) {
-            // TODO: Support retrieving whether a Squeezebox is currently playing. device_data is the object saved
-            // during pairing and callback should return the state in the format callback(err, value).
+            Homey.log('capabilities/onoff/get [device:', device_data.id + ']');
+
+            // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
+            var SqueezeServer = require('squeezenode');
+            var mySqueezeServer = new SqueezeServer(
+                // TODO: Error handling if these are not entered / not correct.
+                Homey.manager('settings').get('serverAddress'),
+                Homey.manager('settings').get('serverPort')
+            );
+
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/onoff/get unavailable [device:', device_data.id + ']');
+                        return;
+                    }
+
+                    mySqueezeServer.players[device_data.id].getStatus(function (reply) {
+                        if (reply.ok) {
+                            Homey.log(
+                                'capabilities/onoff/get state:',
+                                (reply.result.power === 1 ? 'on' : 'off'),
+                                '[device:', device_data.id + ']'
+                            );
+                            callback(null, reply.result.power === 1);
+                        } else {
+                            Homey.log('capabilities/onoff/get error', reply);
+                            callback(reply, null);
+                        }
+                    });
+                }
+            );
         },
 
-        // Start the specified Squeezebox playing whatever is currently in its playlist.
+        set: function (device_data, power, callback) {
+            Homey.log('capabilities/onoff/set', '[device:', device_data.id + ']');
+
+            // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
+            var SqueezeServer = require('squeezenode');
+            var mySqueezeServer = new SqueezeServer(
+                // TODO: Error handling if these are not entered / not correct.
+                Homey.manager('settings').get('serverAddress'),
+                Homey.manager('settings').get('serverPort')
+            );
+
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/onoff/set unavailable [device:', device_data.id + ']');
+                        return;
+                    }
+
+                    mySqueezeServer.players[device_data.id].power(
+                        power,
+                        function (reply) {
+                            if (reply.ok) {
+                                Homey.log(
+                                    'capabilities/onoff/set state:',
+                                    (power ? 'on' : 'off'),
+                                    '[device:', device_data.id + ']'
+                                );
+                                callback(null, power);
+                            } else {
+                                Homey.log('capabilities/onoff/set error', reply);
+                                callback(reply, null);
+                            }
+                        }
+                    );
+                }
+            );
+        }
+    },
+
+    play: {
+        get: function (device_data, callback) {
+            Homey.log('capabilities/play/get', '[device:', device_data.id + ']');
+
+            // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
+            var SqueezeServer = require('squeezenode');
+            var mySqueezeServer = new SqueezeServer(
+                // TODO: Error handling if these are not entered / not correct.
+                Homey.manager('settings').get('serverAddress'),
+                Homey.manager('settings').get('serverPort')
+            );
+
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/play/get unavailable [device:', device_data.id + ']');
+                        return;
+                    }
+
+                    mySqueezeServer.players[device_data.id].getStatus(function (reply) {
+                        if (reply.ok) {
+                            Homey.log(
+                                'capabilities/play/get state', reply.result.mode, '[device:', device_data.id + ']'
+                            );
+                            callback(null, reply.result.mode === 'play');
+                        } else {
+                            Homey.log('capabilities/play/get error', reply);
+                            callback(reply, null);
+                        }
+                    });
+                }
+            );
+        },
+
         set: function (device_data, value, callback) {
+            Homey.log('capabilities/play/set', '[device:', device_data.id + ']');
+
             // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
             var SqueezeServer = require('squeezenode');
             var mySqueezeServer = new SqueezeServer(
@@ -69,49 +178,225 @@ module.exports.capabilities = {
             );
 
             // Start the specified squeezebox playing.
-            mySqueezeServer.on('register', function () {
-                mySqueezeServer.players[device_data.id].play();
-            });
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/play/set unavailable [device:', device_data.id + ']');
+                        return;
+                    }
 
-            // TODO: Detect failures. Is there a way to send the new play state to Homey.
-            if(typeof callback == 'function') {
-                callback(null, true);
-            }
+                    // If value is true then play, otherwise pause.
+                    if (value === true) {
+                        mySqueezeServer.players[device_data.id].play(function (reply) {
+                            if (reply.ok) {
+                                Homey.log('capabilities/play/set state:', value, '[device:', device_data.id + ']');
+                                callback(null, value);
+                            } else {
+                                Homey.log('capabilities/play/set error', reply);
+                                callback(reply, null);
+                            }
+                        });
+                    } else {
+                        Homey.manager('drivers').getDriver('squeezebox').capabilities.pause.set(
+                            device_data,
+                            true,
+                            callback
+                        );
+                    }
+                }
+            );
         }
     },
 
     pause: {
         // Retrieve whether the specified Squeezebox is currently paused.
         get: function (device_data, callback) {
-            // TODO: Support retrieving whether a Squeezebox is currently playing. device_data is the object saved
-            // during pairing and callback should return the state in the format callback(err, value).
-        },
+            Homey.log('capabilities/pause/get [device:', device_data.id + ']');
 
-        // TODO: Currently pausing a paused Squeezebox will start it playing again. Is this what we want?
-        // Pause the specified Squeezebox.
-        set: function (device_data, value, callback) {
             // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
             var SqueezeServer = require('squeezenode');
             var mySqueezeServer = new SqueezeServer(
+                // TODO: Error handling if these are not entered / not correct.
                 Homey.manager('settings').get('serverAddress'),
                 Homey.manager('settings').get('serverPort')
             );
 
-            // Pause the specified Squeezebox.
-            mySqueezeServer.on('register', function () {
-                mySqueezeServer.players[device_data.id].pause();
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/pause/get unavailable [device:', device_data.id + ']');
+                        return;
+                    }
+
+                    mySqueezeServer.players[device_data.id].getStatus(function (reply) {
+                        if (reply.ok) {
+                            Homey.log(
+                                'capabilities/pause/get state', reply.result.mode, '[device:', device_data.id + ']'
+                            );
+                            callback(null, reply.result.mode === 'pause');
+                        } else {
+                            Homey.log('capabilities/pause/get error', reply);
+                            callback(reply, null);
+                        }
+                    });
+                }
+            );
+        },
+
+        set: function (device_data, noToggle, callback) {
+            Homey.log('capabilities/pause/set' + (noToggle ? ' no toggle' : ''), '[device:', device_data.id + ']');
+
+            // TODO: Logitech Media Server supports forced pause natively, but this is not yet supported in SqueezeNode.
+            // If the Squeezebox is paused, sending pause again will start it playing. Prevent this if noToggle is true.
+            // This Promise is resolved IF: noToggle=false OR (noToggle=true AND squeezebox is playing).
+            var okToPause = new Promise(function (resolve, reject) {
+                if (noToggle) {
+                    Homey.manager('drivers').getDriver('squeezebox').capabilities.pause.get(
+                        device_data,
+                        function (err, paused)
+                        {
+                            if (err) {
+                                reject(err);
+                            } else {
+                                resolve(paused === false);
+                            }
+                        }
+                    );
+                } else {
+                    resolve(true);
+                }
             });
 
-            // TODO: Detect failures. Is there a way to send the new pause state to Homey.
-            if(typeof callback == 'function') {
-                callback(null, true);
-            }
+            okToPause.then(
+                function (result) {
+                    if (result === true) {
+                        // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only?
+                        var SqueezeServer = require('squeezenode');
+                        var mySqueezeServer = new SqueezeServer(
+                            Homey.manager('settings').get('serverAddress'),
+                            Homey.manager('settings').get('serverPort')
+                        );
+
+                        mySqueezeServer.on(
+                            'register',
+                            function ()
+                            {
+                                // Is the squeezebox is available (it might be disconnected from the network or power).
+                                if (!mySqueezeServer.players[device_data.id]) {
+                                    Homey.log('capabilities/pause/set unavailable [device:', device_data.id + ']');
+                                    return;
+                                }
+
+                                mySqueezeServer.players[device_data.id].pause(
+                                    function (reply)
+                                    {
+                                        if (reply.ok) {
+                                            Homey.log('capabilities/pause/set true [device:', device_data.id + ']');
+                                            callback(null, true);
+                                        } else {
+                                            callback(reply, null);
+                                        }
+                                    }
+                                );
+                            }
+                        );
+                    } else {
+                        // Nothing has been done, because the Squeezebox is already paused and noToggle was true.
+                        callback(null, true);
+                    }
+                },
+                function (err) {
+                    callback(err, null);
+                }
+            );
         }
     },
 
-    volume: {
+    previous: {
+        set: function (device_data, value, callback) {
+            Homey.log('capabilities/previous/set', '[device:', device_data.id + ']');
+
+            // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
+            var SqueezeServer = require('squeezenode');
+            var mySqueezeServer = new SqueezeServer(
+                // TODO: Error handling if these are not entered / not correct.
+                Homey.manager('settings').get('serverAddress'),
+                Homey.manager('settings').get('serverPort')
+            );
+
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/previous/set unavailable [device:', device_data.id + ']');
+                        return;
+                    }
+
+                    mySqueezeServer.players[device_data.id].previous(function (reply) {
+                        if (reply.ok) {
+                            Homey.log('capabilities/previous/set true [device:', device_data.id + ']');
+                            callback(null, true);
+                        } else {
+                            callback(reply, null);
+                        }
+                    });
+                }
+            );
+        }
+    },
+
+    next: {
+        set: function (device_data, value, callback) {
+            Homey.log('capabilities/next/set', '[device:', device_data.id + ']');
+
+            // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
+            var SqueezeServer = require('squeezenode');
+            var mySqueezeServer = new SqueezeServer(
+                // TODO: Error handling if these are not entered / not correct.
+                Homey.manager('settings').get('serverAddress'),
+                Homey.manager('settings').get('serverPort')
+            );
+
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/next/set unavailable [device:', device_data.id + ']');
+                        return;
+                    }
+
+                    mySqueezeServer.players[device_data.id].next(function (reply) {
+                        if (reply.ok) {
+                            Homey.log('capabilities/next/set true [device:', device_data.id + ']');
+                            callback(null, true);
+                        } else {
+                            callback(reply, null);
+                        }
+                    });
+                }
+            );
+        }
+    },
+
+    mediacontrol: {
+        set: function (device_data, value, callback) {
+            Homey.log('capabilities/mediacontrol/set', value, '[device:', device_data.id + ']');
+            Homey.manager('drivers').getDriver('squeezebox').capabilities[value].set(device_data, null, callback);
+        }
+    },
+
+    // TODO: Not really convinced "volume_set" is the right name, but alas this is what Homey dictates.
+    volume_set: {
         // Retrieve the current volume level of the specified Squeezebox.
         get: function (device_data, callback) {
+            Homey.log('capabilities/volume_set/get [device:', device_data.id + ']');
+
             // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
             var SqueezeServer = require('squeezenode');
             var mySqueezeServer = new SqueezeServer(
@@ -120,20 +405,33 @@ module.exports.capabilities = {
             );
 
             // Get the volume level of the specified Squeezebox.
-            var volume;
-            mySqueezeServer.on('register', function () {
-                volume = mySqueezeServer.players[device_data.id].getVolume();
-            });
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/volume_set/get unavailable [device:', device_data.id + ']');
+                        return;
+                    }
+                    mySqueezeServer.players[device_data.id].getVolume(function (reply) {
+                        // Convert volume for Homey.
+                        var value = reply.result / 100;
 
-            // TODO: Detect failures.
-            // Send the volume level to Homey.
-            if(typeof callback == 'function') {
-                callback(null, volume);
-            }
+                        // TODO: Detect failures.
+                        // Send the volume level to Homey.
+                        if(typeof callback === 'function') {
+                            Homey.log('capabilities/volume_set/get value', value, '[device:', device_data.id + ']');
+                            callback(null, value);
+                        }
+                    });
+                }
+            );
         },
 
         // Set the volume level of the specified Squeezebox.
         set: function (device_data, value, callback) {
+            Homey.log('capabilities/volume_set/set [device:', device_data.id + ']');
+
             // TODO: The instantiation of mySqueezeServer is currently NOT DRY. Should it be done once only? Memory?
             var SqueezeServer = require('squeezenode');
             var mySqueezeServer = new SqueezeServer(
@@ -142,15 +440,31 @@ module.exports.capabilities = {
             );
 
             // Set the volume level of the specified Squeezebox.
-            mySqueezeServer.on('register', function () {
-                mySqueezeServer.players[device_data.id].setVolume(value);
-            });
+            mySqueezeServer.on(
+                'register',
+                function () {
+                    // Is the squeezebox is available (it might be disconnected from the network or power).
+                    if (!mySqueezeServer.players[device_data.id]) {
+                        Homey.log('capabilities/volume_set/set unavailable [device:', device_data.id + ']');
+                        return;
+                    }
 
-            // TODO: Detect failures. Is there a way to return the new volume level and if so should volume level be
-            // read from the Squeezebox, rather than just parroted back?
-            if(typeof callback == 'function') {
-                callback(null, true);
-            }
+                    // Convert volume for Squeezebox.
+                    value = value * 100;
+
+                    mySqueezeServer.players[device_data.id].setVolume(
+                        value,
+                        function (reply) {
+                            if (reply.ok) {
+                                Homey.log('capabilities/volume_set/set state:', value, '[device:', device_data.id + ']');
+                                callback(null, value);
+                            } else {
+                                callback(reply, null);
+                            }
+                        }
+                    );
+                }
+            );
         }
     }
 };


### PR DESCRIPTION
Credit to @Inversion-Nl for the majority of the work in this commit.

Mobile card now available and additional capabilities added. Now supports extra capabilities of: onoff, getting play and pause status, previous, next, mediacontrol (specifically used for the mobile card ternary). Also volume get and set work now.